### PR TITLE
Swallow NotebookEditor.notebook npe

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-jupyter-cell-tags",
 	"displayName": "Jupyter Cell Tags",
 	"description": "Jupyter Cell Tags support for VS Code",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"publisher": "ms-toolsai",
 	"preview": true,
 	"icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-jupyter-cell-tags",
 	"displayName": "Jupyter Cell Tags",
 	"description": "Jupyter Cell Tags support for VS Code",
-	"version": "0.1.6",
+	"version": "0.1.5",
 	"publisher": "ms-toolsai",
 	"preview": true,
 	"icon": "icon.png",

--- a/src/cellTags.ts
+++ b/src/cellTags.ts
@@ -77,6 +77,10 @@ export function getActiveCell() {
 		return;
 	}
 
+	if (editor.selections[0].start >= editor.notebook.cellCount) {
+		return;
+	}
+
 	return editor.notebook.cellAt(editor.selections[0].start);
 }
 

--- a/src/cellTags.ts
+++ b/src/cellTags.ts
@@ -73,7 +73,7 @@ export class CellTagStatusBarProvider implements vscode.NotebookCellStatusBarIte
 export function getActiveCell() {
 	// find active cell
 	const editor = vscode.window.activeNotebookEditor;
-	if (!editor) {
+	if (!editor || !editor.notebook) {
 		return;
 	}
 

--- a/src/cellTags.ts
+++ b/src/cellTags.ts
@@ -73,7 +73,7 @@ export class CellTagStatusBarProvider implements vscode.NotebookCellStatusBarIte
 export function getActiveCell() {
 	// find active cell
 	const editor = vscode.window.activeNotebookEditor;
-	if (!editor || !editor.notebook) {
+	if (!editor) {
 		return;
 	}
 

--- a/src/cellTagsTreeDataProvider.ts
+++ b/src/cellTagsTreeDataProvider.ts
@@ -53,6 +53,10 @@ export class TagTreeDataProvider implements vscode.TreeDataProvider<string> {
 			return;
 		}
 
+		if (editor.selections[0].start >= editor.notebook.cellCount) {
+			return;
+		}
+
 		const activeCell = editor.notebook.cellAt(editor.selections[0].start);
 		if (!activeCell) {
 			this._tags = [];

--- a/src/cellTagsTreeDataProvider.ts
+++ b/src/cellTagsTreeDataProvider.ts
@@ -53,10 +53,6 @@ export class TagTreeDataProvider implements vscode.TreeDataProvider<string> {
 			return;
 		}
 
-		if (!editor.notebook) {
-			return;
-		}
-
 		const activeCell = editor.notebook.cellAt(editor.selections[0].start);
 		if (!activeCell) {
 			this._tags = [];

--- a/src/cellTagsTreeDataProvider.ts
+++ b/src/cellTagsTreeDataProvider.ts
@@ -53,6 +53,10 @@ export class TagTreeDataProvider implements vscode.TreeDataProvider<string> {
 			return;
 		}
 
+		if (!editor.notebook) {
+			return;
+		}
+
 		const activeCell = editor.notebook.cellAt(editor.selections[0].start);
 		if (!activeCell) {
 			this._tags = [];


### PR DESCRIPTION
We are seeing `NotebookEditor.notebook` being undefined in tests, here we swallow the error first to unblock Jupyter extension CI.