### PR TITLE
Show cell tags view only when notebook is opened.

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,10 +94,17 @@
 				{
 					"id": "cell-tag",
 					"name": "Cell Tags",
-					"contextualTitle": "Jupyter Cell Tags"
+					"type": "tree",
+					"when": "jupyter:showTagsExplorer"
 				}
 			]
-		}
+		},
+		"viewsWelcome": [
+			{
+				"view": "cell-tag",
+				"contents": "No tags found for the selected cell. Use the [Add Cell Tag](command:jupyter-cell-tags.addTag) command to add tags."
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",

--- a/src/cellTagsTreeDataProvider.ts
+++ b/src/cellTagsTreeDataProvider.ts
@@ -23,12 +23,14 @@ export class TagTreeDataProvider implements vscode.TreeDataProvider<string> {
 		}
 	}
 
-	private registerEditorListeners(editor: vscode.NotebookEditor | undefined) {
+	private async registerEditorListeners(editor: vscode.NotebookEditor | undefined) {
 		this._editorDisposables.forEach(d => d.dispose());
 
 		if (!editor) {
 			return;
 		}
+
+		vscode.commands.executeCommand('setContext', 'jupyter:showTagsExplorer', true);
 
 		this._editorDisposables = [];
 		this._editorDisposables.push(vscode.window.onDidChangeNotebookEditorSelection(e => {


### PR DESCRIPTION
Don't register the view before users ever open a notebook.