### PR TITLE
Contribute cell tags to Jupyter panel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,12 +90,14 @@
 			]
 		},
 		"views": {
-			"jupyter": [
+			"jupyter-variables": [
 				{
 					"id": "cell-tag",
 					"name": "Cell Tags",
 					"type": "tree",
-					"when": "jupyter:showTagsExplorer"
+					"icon": "$(tag)",
+					"when": "jupyter:showTagsExplorer",
+					"visibility": "collapsed"
 				}
 			]
 		},


### PR DESCRIPTION
Reuse the Variables View Panel instead of creating a new side bar view container.