### PR TITLE
Added the ability to add tags to multiple selected cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 	],
 	"activationEvents": [
 		"onNotebook:jupyter-notebook",
+		"onNotebookEditor:editor.selection",
+		"onNotebookEditor:editor.onDidChangeActiveNotebookEditor",
 		"onCommand:jupyter-cell-tags.removeTag",
 		"onCommand:jupyter-cell-tags.addTag",
 		"onCommand:jupyter-cell-tags.editTagsInJSON",
@@ -42,7 +44,14 @@
 			{
 				"command": "jupyter-cell-tags.addTag",
 				"title": "Add Cell Tag",
-				"icon": "$(add)"
+				"icon": "$(add)",
+				"when": "jupyter-cell-tags.singleCellSelected"
+			},
+			{
+				"command": "jupyter-cell-tags.addTagsToSelectedCells",
+				"title": "Add Tags to Selected Cells",
+				"icon": "$(add)",
+				"when": "jupyter-cell-tags.multipleCellsSelected"
 			},
 			{
 				"command": "jupyter-cell-tags.editTagsInJSON",
@@ -58,6 +67,12 @@
 			"notebook/cell/title": [
 				{
 					"command": "jupyter-cell-tags.addTag",
+					"when": "jupyter-cell-tags.singleCellSelected",
+					"group": "jupytercelltags@1"
+				},
+				{
+					"command": "jupyter-cell-tags.addTagsToSelectedCells",
+					"when": "jupyter-cell-tags.multipleCellsSelected",
 					"group": "jupytercelltags@1"
 				},
 				{

--- a/src/cellTags.ts
+++ b/src/cellTags.ts
@@ -20,6 +20,12 @@ export async function addCellTag(cell: vscode.NotebookCell, tags: string[]) {
     await updateCellTags(cell, oldTags);
 }
 
+export async function addTagsToMultipleCells(cells: vscode.NotebookCell[], tags: string[]) {
+    for (const cell of cells) {
+        await addCellTag(cell, tags);
+    }
+}
+
 export class CellTagStatusBarProvider implements vscode.NotebookCellStatusBarItemProvider {
     provideCellStatusBarItems(
         cell: vscode.NotebookCell,
@@ -69,6 +75,20 @@ export function getActiveCell() {
     }
 
     return editor.notebook.cellAt(editor.selections[0].start);
+}
+
+
+export function getActiveCells(): vscode.NotebookCell[] | undefined {
+    const editor = vscode.window.activeNotebookEditor;
+    if (!editor) {
+        return;
+    }
+
+    let cells: vscode.NotebookCell[] = [];
+    for (const selection of editor.selections) {
+        cells = cells.concat(editor.notebook.getCells(selection));
+    }
+    return cells.length > 0 ? cells : undefined;
 }
 
 export function reviveCell(args: vscode.NotebookCell | vscode.Uri | undefined): vscode.NotebookCell | undefined {
@@ -156,6 +176,26 @@ export function register(context: vscode.ExtensionContext) {
             }
         )
     );
+
+	context.subscriptions.push(vscode.commands.registerCommand('jupyter-cell-tags.addTagsToSelectedCells', async () => {
+	    const activeCells = getActiveCells();
+	    if (!activeCells) {
+	        return;
+	    }
+	    const disposables: vscode.Disposable[] = [];
+	    try {
+			const tag = await vscode.window.showInputBox({
+				placeHolder: 'Type to create a cell tag'
+			});
+
+	        if (tag) {
+	            await addTagsToMultipleCells(activeCells, [tag]);
+	        }
+	    } finally {
+	        disposables.forEach(d => d.dispose());
+	    }
+	}));
+
 
     context.subscriptions.push(
         vscode.commands.registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,41 @@ import { register as registerCellTagsView } from './cellTagsTreeDataProvider';
 export function activate(context: vscode.ExtensionContext) {
 	registerCellTags(context);
 	registerCellTagsView(context);
+
+	// Update context when the active editor or selection changes
+	vscode.window.onDidChangeActiveNotebookEditor(updateContext);
+	vscode.window.onDidChangeNotebookEditorSelection(updateContext);
+
+	updateContext();
 }
+
+function updateContext() {
+    const editor = vscode.window.activeNotebookEditor;
+    if (!editor) {
+        vscode.commands.executeCommand('setContext', 'jupyter-cell-tags.singleCellSelected', false);
+        vscode.commands.executeCommand('setContext', 'jupyter-cell-tags.multipleCellsSelected', false);
+        return;
+    }
+
+    const selections: readonly vscode.NotebookRange[] = editor.selections; // NotebookRange[]
+    const selectedRangesCount = selections.length;
+    var total_num_selected_cells = 0;
+    selections.forEach(selection => {
+        const range = selection as vscode.NotebookRange;
+        if (!range.isEmpty) {
+            const num_selected_cells = range.end - range.start
+            total_num_selected_cells += num_selected_cells;
+        }
+    });
+    // TODO 2024-09-05 17:47: - [ ] Got num selected cells nearly working, it will always be correct to tell if 1 vs. many cells.
+    // Noticed error below, there were only 3 cells in the notebook but it returned 4 cells. I think the last index should be excluded but then it would give zero for single cell selections?
+    // Selection num ranges count: 1
+    // 	Selected cells: Start(0), End(4)
+    // Selection count: 4
+    const selectionCount = total_num_selected_cells;
+    vscode.commands.executeCommand('setContext', 'jupyter-cell-tags.singleCellSelected', selectionCount === 1);
+    vscode.commands.executeCommand('setContext', 'jupyter-cell-tags.multipleCellsSelected', selectionCount > 1);
+}
+
 
 export function deactivate() {}


### PR DESCRIPTION
Added a contextually-enabled command "jupyter-cell-tags.addTagsToSelectedCells" that becomes enabled and appears in the context menu (replacing the "jupyter-cell-tags.addTag" command) when multiple notebook cells are selected.

https://github.com/microsoft/vscode-jupyter-cell-tags/issues/38#issue-2408608168


![image](https://github.com/user-attachments/assets/8bcc2a45-9f64-4141-b5ce-6a103df03a0b)
