### PR TITLE
fix: hide addTag and removeTag commands from palette outside notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,16 @@
 					"when": "view == cell-tag",
 					"group": "inline"
 				}
+			],
+			"commandPalette": [
+				{
+					"command": "jupyter-cell-tags.addTag",
+					"when": "notebookEditorFocused"
+				},
+				{
+					"command": "jupyter-cell-tags.removeTag",
+					"when": "notebookEditorFocused"
+				}
 			]
 		},
 		"views": {


### PR DESCRIPTION
Fixes #14573

## Problem

The `jupyter-cell-tags.addTag` and `jupyter-cell-tags.removeTag` commands always show up in the command palette, even when there is no notebook editor open. Since these commands only make sense in the context of a notebook cell, showing them at all times is confusing.

## Fix

Added a `commandPalette` menu entry for both commands with `when: notebookEditorFocused`. This hides them from the command palette unless a notebook editor is currently focused, which is consistent with how other notebook-specific UI (like the `cell-tag` view) is gated in this extension.

## Test plan

- [ ] Open a plain `.py` file or any non-notebook file -- `Add Cell Tag` and `Remove Cell Tag` should not appear in the command palette
- [ ] Open a Jupyter notebook (`.ipynb`) and focus the notebook editor -- both commands should appear in the command palette
